### PR TITLE
fix: remove getting alias for models

### DIFF
--- a/pydantic_filters/drivers/sqlalchemy/_mapping.py
+++ b/pydantic_filters/drivers/sqlalchemy/_mapping.py
@@ -15,13 +15,13 @@ _Model = TypeVar("_Model", bound=so.DeclarativeBase)
 
 @dataclass
 class JoinParams:
-    target: Union[Type[so.DeclarativeBase], so.util.AliasedClass]
+    target: Type[so.DeclarativeBase]
     on_clause: sa.ColumnExpressionArgument
 
 
 def filter_to_column_clauses(
         filter_: _Filter,
-        model: Union[Type[_Model], so.util.AliasedClass],
+        model: Type[_Model],
 ) -> List[sa.ColumnExpressionArgument]:
     """Data from the filter to the list of expressions for SQLAlchemy
 
@@ -122,25 +122,19 @@ def filter_to_join_targets(
             ) from e
 
         nested_class: Type[_Model] = relationship.entity.class_
-        nested_class_aliased: so.util.AliasedClass = so.aliased(nested_class)
-
-        def replace_by_aliased(__c: sa.Column) -> sa.Column:
-            if __c.table is nested_class.__table__:
-                return getattr(nested_class_aliased, __c.key)
-            return __c
 
         clauses = cast(
             List[sa.ColumnExpressionArgument],
             [
-                replace_by_aliased(pair[0]) == replace_by_aliased(pair[1])
+                pair[0] == pair[1]
                 for pair in relationship.local_remote_pairs],
         )
         clauses.extend(
-            filter_to_column_clauses(filter_=nested_filter, model=nested_class_aliased),
+            filter_to_column_clauses(filter_=nested_filter, model=nested_class),
         )
         targets.append(
             JoinParams(
-                target=nested_class_aliased,
+                target=nested_class,
                 on_clause=sa.and_(*clauses),
             ),
         )

--- a/pydantic_filters/drivers/sqlalchemy/_mapping.py
+++ b/pydantic_filters/drivers/sqlalchemy/_mapping.py
@@ -104,9 +104,14 @@ def filter_to_join_targets(
         model: Type[so.DeclarativeBase],
 ) -> List[JoinParams]:
     """Get targets to join"""
+    
+    inspected: so.Mapper = sa.inspect(model)
+    try:
+        mapper = inspected if inspected.is_mapper else inspected.mapper
+    except AttributeError:
+        mapper = inspected
 
     targets = []
-    mapper: so.Mapper = sa.inspect(model)
 
     for field_name in filter_.nested_filters:
         nested_filter = getattr(filter_, field_name)
@@ -122,24 +127,33 @@ def filter_to_join_targets(
             ) from e
 
         nested_class: Type[_Model] = relationship.entity.class_
+        nested_class_aliased: so.util.AliasedClass = so.aliased(nested_class)
+
+        def replace_by_aliased(__c: sa.Column) -> sa.Column:
+            if __c.table is nested_class.__table__:
+                return getattr(nested_class_aliased, __c.key)
+            if __c.table is model.__table__:
+                return getattr(model, __c.key)
+            return __c
 
         clauses = cast(
             List[sa.ColumnExpressionArgument],
             [
-                pair[0] == pair[1]
-                for pair in relationship.local_remote_pairs],
+                replace_by_aliased(pair[0]) == replace_by_aliased(pair[1])
+                for pair in relationship.local_remote_pairs
+            ],
         )
         clauses.extend(
-            filter_to_column_clauses(filter_=nested_filter, model=nested_class),
+            filter_to_column_clauses(filter_=nested_filter, model=nested_class_aliased),
         )
         targets.append(
             JoinParams(
-                target=nested_class,
+                target=nested_class_aliased,
                 on_clause=sa.and_(*clauses),
             ),
         )
 
-        nested_targets = filter_to_join_targets(filter_=nested_filter, model=nested_class)
+        nested_targets = filter_to_join_targets(filter_=nested_filter, model=nested_class_aliased)
         targets.extend(nested_targets)
 
     return targets


### PR DESCRIPTION
I have a bug with library when I using `append_to_statement` sqlalchemy driver function.

I have 3 SQLModel (same as SQLAlchemy) models :
```python
class Profile(BaseSQLModel, table=True, metadata=metadata):
    __tablename__ = "profiles"

    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
    bank_profile_id: str

class Account(BaseSQLModel, table=True, metadata=metadata):
    __tablename__ = "accounts"

    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
    profile_id: uuid.UUID = Field(foreign_key=f"{Profile.__tablename__}.id")

    profile: Profile = Relationship(
        sa_relationship_kwargs={"lazy": None, "viewonly": True},
    )

class Transaction(BaseSQLModel, table=True, metadata=metadata):
    __tablename__ = "transactions"

    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
    account_id: uuid.UUID = Field(foreign_key=f"{Account.__tablename__}.id")
    ...

    account: Account = Relationship(
        sa_relationship_kwargs={"lazy": None, "viewonly": True},
    )
```

Have filters:
```python
class TransactionFilter(BaseFilter):
    ...
    account_id: set[uuid.UUID]
    account: AccountFilter

class AccountFilter(BaseFilter):
    ...
    profile_id: set[uuid.UUID]
    profile: ProfileFilter

class ProfileFilter(BaseFilter):
    ...
    bank_profile_id: set[str]
```

And making this request for SQLite (aiosqlite) database:
```python
filter_ = TransactionFilter(
    account=AccountFilter(
        profile=ProfileFilter(bank_profile_id={"+1234567890"}),
    ),
)
...
statement = select(Transaction)
statement = append_to_statement(
    statement=statement,
    model=Transaction,
    filter_=filter_,
    pagination=pagination,
    sort=sort,
)

result = await self.session.exec(statement)
db_transactions = result.all()
```
And when I execute query I get exception:
```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such column: accounts.profile_id
[SQL: SELECT transactions.id, transactions.bank_transaction_id, transactions.account_id, transactions.amount, transactions.currency, transactions.type, transactions.bank_participator_id, transactions.status, transactions.created_at FROM transactions JOIN accounts AS accounts_1 ON transactions.account_id = accounts_1.id JOIN profiles AS profiles_1 ON accounts.profile_id = profiles_1.id AND profiles_1.bank_profile_id IN (?) ORDER BY transactions.bank_transaction_id ASC LIMIT ? OFFSET ?]
```

I removed generating clause with aliased and it work now for me. Maybe, you can find better solution without degradating.